### PR TITLE
Solve error with names containing the full path

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -668,10 +668,11 @@ if __name__=='__main__':
             # this may not be present, in which case we have to
             # remake.
             cachedir=find_cache_dir(o)
-            if not(os.path.isfile(cachedir+'/'+o['full_mslist']+'.ddfcache/LastResidual')) or not(os.path.isfile(cachedir+'/'+o['full_mslist']+'.ddfcache/PSF')):
-                ddf_image('image_full_ampphase1m_reimage',o['full_mslist'],cleanmask='image_full_ampphase1.app.restored.fits.mask.fits',cleanmode='SSD',ddsols=ddsols,applysols='AP',majorcycles=0,robust=o['final_robust'],colname=colname,use_dicomodel=True,dicomodel_base='image_full_ampphase1m',peakfactor=0.001,automask=True,automask_threshold=o['thresholds'][3],smooth=True,normalization=o['normalize'][2],reuse_psf=False,dirty_from_resid=False,uvrange=uvrange,apply_weights=o['apply_weights'][3],catcher=catcher,**ddf_kw)
-                os.symlink('Dirty',cachedir+'/'+o['full_mslist']+'.ddfcache/LastResidual')
-                os.symlink('Dirty.hash',cachedir+'/'+o['full_mslist']+'LastResidual.hash')
+            full_mslist_file = os.path.basename(o['full_mslist'])
+            if not(os.path.isfile(cachedir+'/'+full_mslist_file+'.ddfcache/LastResidual')) or not(os.path.isfile(cachedir+'/'+full_mslist_file+'.ddfcache/PSF')):
+                ddf_image('image_full_ampphase1m_reimage',full_mslist_file,cleanmask='image_full_ampphase1.app.restored.fits.mask.fits',cleanmode='SSD',ddsols=ddsols,applysols='AP',majorcycles=0,robust=o['final_robust'],colname=colname,use_dicomodel=True,dicomodel_base='image_full_ampphase1m',peakfactor=0.001,automask=True,automask_threshold=o['thresholds'][3],smooth=True,normalization=o['normalize'][2],reuse_psf=False,dirty_from_resid=False,uvrange=uvrange,apply_weights=o['apply_weights'][3],catcher=catcher,**ddf_kw)
+                os.symlink('Dirty',cachedir+'/'+full_mslist_file+'.ddfcache/LastResidual')
+                os.symlink('Dirty.hash',cachedir+'/'+full_mslist_file+'LastResidual.hash')
 
             ddf_shift(last_image_root,facet_offset_file,options=o,catcher=catcher)
 


### PR DESCRIPTION
If the option "full_mslist" contains the full path, the pipeline fails being unable to find the correct path to the cache files to create the simlink. This patch solves this problem and should be backwards compatible.