### PR TITLE
Use of alternative library as discussed in #91

### DIFF
--- a/utils/surveys_db.py
+++ b/utils/surveys_db.py
@@ -1,9 +1,14 @@
 import sshtunnel
 import socket
-import MySQLdb as mdb
-import MySQLdb.cursors as mdbcursors
 import os
 import datetime
+try:
+    import MySQLdb as mdb
+    import MySQLdb.cursors as mdbcursors
+except ImportError:
+    import pymysql as mdb
+    import pymysql.cursors as mdbcursors
+
 
 def get_next():
     # return the name of the top-priority field with appropriate status


### PR DESCRIPTION
Import the alternative library where the MySQLdb cannot be installed. It should not interfere with the production run.