### PR TITLE
fix if there is one ms file

### DIFF
--- a/scripts/sub-sources-outside-region.py
+++ b/scripts/sub-sources-outside-region.py
@@ -101,6 +101,9 @@ def add_dummyms(msfiles):
     '''
     Add dummy ms to create a regular freuqency grid when doing a concat with DPPP
     '''
+    if len(msfiles) == 1: # there is nothing to do
+        return msfiles
+    
     keyname = 'REF_FREQUENCY'
     freqaxis = []
     newmslist  = []


### PR DESCRIPTION
Script crashed when there was only one file in the mslist (there is nothing to order in that case). Fixed by simple check.