### PR TITLE
fix bug baseline based averaging

### DIFF
--- a/scripts/runwsclean.py
+++ b/scripts/runwsclean.py
@@ -1150,7 +1150,8 @@ def makeimage(mslist, imageout, pixsize, imsize, channelsout, niter, robust, uvt
       imcol = 'DATA' 
     t.close()
     
-    baselineav = str (old_div(2.5e3*60000.*2.*np.pi *np.float(pixsize),(24.*60.*60*np.float(imsize))) )
+    #baselineav = str (old_div(2.5e3*60000.*2.*np.pi *np.float(pixsize),(24.*60.*60*np.float(imsize))) )
+    baselineav = str (old_div(1.87e3*60000.*2.*np.pi *np.float(1.5),(24.*60.*60*np.float(imsize))) )
     #baselineav = str (5e4*60000.*2.*np.pi *np.float(pixsize)/(24.*60.*60*np.float(imsize)) ) # this would mean 4sec for 20000 px image
     #imcol = 'DATA' 
     


### PR DESCRIPTION
fix bug in baseline based averaging, scaling with pixel size should not have been included (only imsize). This does not make a difference for the default HBA extract selfcal but it is important for selfcal at lower resolution or frequency (e.g., LBA).