### PR TITLE
Update ddf-py3.singularity

### DIFF
--- a/ddf-py3.singularity
+++ b/ddf-py3.singularity
@@ -200,7 +200,7 @@ From: debian:bullseye
   apt-get -y autoremove
   rm -rf /var/lib/apt/lists/*
   
-  bash -c "rm -rf /usr/local/src/{DP3,EveryBeam,LOFARBeam,aoflagger,dysco,idg,wsclean,PyBDSF,killMS,SpiderScripts}/" # DDFacet
+  bash -c "rm -rf /usr/local/src/{DP3,EveryBeam,LOFARBeam,aoflagger,dysco,idg,wsclean,PyBDSF,SpiderScripts}/" # DDFacet,killMS
   ln -s /usr/local/bin/DPPP /usr/local/bin/DP3
 
 # %runscript


### PR DESCRIPTION
Fix for "ClipCal.py: not found"