### PR TITLE
remove bias from NVSS flux density scale alignment

### DIFF
--- a/scripts/quality_pipeline.py
+++ b/scripts/quality_pipeline.py
@@ -239,12 +239,16 @@ if __name__=='__main__':
     else:
         tgss_scale=None
     if 'NVSS' in o['list']:
-        t=Table.read(o['catprefix']+'.cat.fits_NVSS_match_filtered.fits')
-        t=t[t['Total_flux']>30e-3]
-        ratios=old_div(t['Total_flux'],t['NVSS_Total_flux'])
+        nvss_scale = 5.9124  # expected ratio for perfect flux scale
+        for i in range(5):  # do this iteratively to remove bias from flux cut if flux scale factor non-unity
+            t=Table.read(o['catprefix']+'.cat.fits_NVSS_match_filtered.fits')
+            t = t[t['Total_flux']>200e-3/(5.9124/nvss_scale)]  # 200mJy~ 6C completeness (190 mJy * (144/151)^-0.783). Correct for estimate of flux scale
+            # t=t[t['Total_flux']>30e-3]
+            ratios=old_div(t['Total_flux'],t['NVSS_Total_flux'])
+            print(np.median(ratios), len(ratios))
+            nvss_scale = np.median(ratios)
         bsratio=np.percentile(bootstrap(ratios,np.median,10000),(16,84))
         print('Median LOFAR/NVSS ratio is %.3f (1-sigma %.3f -- %.3f)' % (np.median(ratios),bsratio[0],bsratio[1]))
-        nvss_scale=np.median(ratios)
     else:
         nvss_scale=None
     # Noise estimate


### PR DESCRIPTION
Hi, 
I suspect the way the flux scale is currently aligned with NVSS might introduce some ~10% bias:
We align the flux scale such that the median spectral index between LOFAR and NVSS is identical to the median SI found between 6C and NVSS. 
However, for LOFAR sources >30 mJy are considered, while the flux completeness of 6C is only 190 mJy. Since the median SI for sources >30 mJy is different from the median SI of sources > 190 mJy, this introduces bias. An easy solution is to only consider sources that are detectable at 6C sensitivity (>200 mJy at 144MHz). This comes at the cost of decreasing the the statistic to ~100 sources/field or so.

Another (minor) bias might arise from cutting in flux before correcting the scale, since if the scale correction is significant, it also needs to be considered in the flux cut. A possible solution is to iterate a few times. This makes a difference for some of my Virgo fields, although for LoTSS where the data is cleaner, it might be negligible. 

Cheers,
Henrik
