### PR TITLE
Update find_mosaic_pointings.py

### DIFF
--- a/utils/find_mosaic_pointings.py
+++ b/utils/find_mosaic_pointings.py
@@ -24,6 +24,8 @@ def read_pointingfile(pointingfilename=None):
 
     # turn list of dicts into dict of lists...
     for f in fields:
+        if f['lotss_field'] != 1:
+                continue
         pointingname=f['id']
         pointingdict[pointingname] = [f['status'],f['ra'],f['decl']]
     return pointingdict


### PR DESCRIPTION
Adding:

if f['lotss_field'] != 1:
      continue

In the read_pointingfile function. This means that only lotss fields are picked up for mosaicing.