### PR TITLE
Update mosaic.py

### DIFF
--- a/scripts/mosaic.py
+++ b/scripts/mosaic.py
@@ -314,7 +314,7 @@ def make_mosaic(args):
 
         hdu = fits.PrimaryHDU(header=header,data=isum)
         if args.do_lowres:
-            mosname='low-mosaic.fits'
+            mosname='mosaic.fits'
         else:
             mosname='mosaic.fits'
         hdu.writeto(rootname+mosname,overwrite=True)


### PR DESCRIPTION
Rename mosname when do_lowres. Otherwise the mosaics are called low-low-mosaic.fits and it crashes when trying to blanked low-mosaic.fits. This is because the rootname is already set to "low"