### PR TITLE
Make extract handle offset of first and last solints

### DIFF
--- a/utils/fixsymlinks.py
+++ b/utils/fixsymlinks.py
@@ -8,7 +8,16 @@ import numpy as np
 def get_solutions_timerange(sols):
     print('Reading %s'%sols)
     S=np.load(sols)
-    t = np.concatenate([S["Sols"]["t0"],S["Sols"]["t1"]])    
+    t = np.concatenate([S["Sols"]["t0"],S["Sols"]["t1"]])
+    # Fix for when first and last time slots are offset.
+    tdiff = np.diff(t, 2)
+    if not np.allclose(tdiff, 0):
+        offset_start = tdiff[0]
+        offset_end = tdiff[-1]
+        print('Found offset of %d, %d for first and last time slots.'%(offset_start,offset_end))
+        # +1 seems needed to match the time in the solution filename.
+        t[0] -= offset_start + 1
+        t[-1] -= offset_end
     return np.min(t),np.max(t)
 
 def fixsymlinks(ddsols,workdir='.',stype='smoothed',verbose=True,delete_existing=False):


### PR DESCRIPTION
Maybe related to/introduced with #327 and #329.

It seems some fields can have solutions where the first and last time slots have a different offset from the solution interval. Running an extract, `fixsymlinks` seem to fall over on this field because of this:
```python
def get_solutions_timerange(sols):
    print('Reading %s'%sols)
    S=np.load(sols)
    t = np.concatenate([S["Sols"]["t0"],S["Sols"]["t1"]])    
    print(np.diff(t))
```
gives me
```
[-1030.     30.     30. ...     30.     30.  1030.]
```

The DDS3 solutions are named `DDS3_full_5000558403.01_smoothed.npz`, but the offset causes it to look for `DDS3_full_5000557404*_smoothed.npz`. The old version before #329 finds it correctly using the `BeamTimes` entry:
```python
In [6]: np.min(sols['BeamTimes'])
Out[6]: 5000558403.005561
```

Switching from `BeamTimes` seems to fix #329, so this pull request expands on it and adds a check that tries to detect these offsets and get the correct time corresponding to the solution file that way. It is single-run statistics though, so it might be good if someone who's more versed in the extracts can verify this doesn't have unintended side effects (in case the function is used elsewhere, for example).