### PR TITLE
add tuple(slice) in align-extrationimage-fluxes.py

### DIFF
--- a/scripts/align-extrationimage-fluxes.py
+++ b/scripts/align-extrationimage-fluxes.py
@@ -80,7 +80,7 @@ def flatten(f):
         else:
             slice.append(0)
         
-    hdu = fits.PrimaryHDU(header=header,data=f[0].data[slice])
+    hdu = fits.PrimaryHDU(header=header,data=f[0].data[tuple(slice)])
     return hdu
 
 


### PR DESCRIPTION
to solve the following error 

Traceback (most recent call last):
  File "/data2/botteon/fluxalign/align-extrationimage-fluxes.py", line 206, in <module>
    lotssdr2 = filter_outside_extract(regionfile,infile,lotssdr2)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data2/botteon/fluxalign/align-extrationimage-fluxes.py", line 90, in filter_outside_extract
    hduflat = flatten(hdu)
              ^^^^^^^^^^^^
  File "/data2/botteon/fluxalign/align-extrationimage-fluxes.py", line 83, in flatten
    hdu = fits.PrimaryHDU(header=header,data=f[0].data[slice])
                                             ~~~~~~~~~^^^^^^^
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices