### PR TITLE
Extract only LoTSS data

### DIFF
--- a/scripts/extraction.py
+++ b/scripts/extraction.py
@@ -84,7 +84,21 @@ fields=t[t['sep']<2.2*u.deg]
 if len(fields)==0:
     die('No fields within 2.2 degrees of pointing position',database=False)
 
-print('We will use the following fields')
+separator('Fields found')
+print(fields)
+
+only_LoTSS = []
+for f in fields["Field"]:
+    if f.startswith('P') and f[1].isdigit():
+        only_LoTSS.append(True)
+    else:
+        print()
+        print(f'{f} is not a LoTSS pointing, we will not use it for the extraction')
+        only_LoTSS.append(False)
+
+fields = fields[only_LoTSS]
+
+separator('We will use the following LoTSS fields')
 print(fields)
 
 separator('Making working directory')


### PR DESCRIPTION
The extraction script is querying the entire database, which contains also pointings that are not part of LoTSS. As you need specific macaroons to rclone pointings that are not LoTSS, the extraction was crashing. With this edit we check if a pointing belongs to LoTSS or not (ie if its Field name starts with P[0..9])